### PR TITLE
feat: sync theme palette and token colors with srcery-vim

### DIFF
--- a/docs/superpowers/specs/2026-05-30-srcery-vim-sync-design.md
+++ b/docs/superpowers/specs/2026-05-30-srcery-vim-sync-design.md
@@ -1,0 +1,100 @@
+# Design: Sync VS Code Theme Against srcery-vim
+
+Date: 2026-05-30
+
+## Goal
+
+Bring `themes/Srcery-color-theme.json` into strict alignment with the canonical srcery-vim color palette and highlight group assignments, without restructuring the VS Code/TextMate scope model.
+
+## Reference
+
+Upstream: `srcery-colors/srcery-vim` — `colors/srcery.vim`
+
+Canonical palette (hex, lowercase):
+
+| Name | Hex |
+|------|-----|
+| black | #121110 |
+| hard_black | #121212 |
+| gray1 | #1c1b19 |
+| bright_black | #917e6b |
+| white | #c5b088 |
+| bright_white | #fce8c3 |
+| red | #ef2f27 |
+| bright_red | #f75341 |
+| green | #519f50 |
+| bright_green | #98bc37 |
+| yellow | #fbb829 |
+| bright_yellow | #fed06e |
+| blue | #2c78bf |
+| bright_blue | #68a8e4 |
+| magenta | #e02c6d |
+| bright_magenta | #ff5c8f |
+| cyan | #0aaeb3 |
+| bright_cyan | #2be4d0 |
+| bright_orange | #ff8700 |
+
+## Changes Required
+
+### 1. Terminal ANSI colors (3 fixes)
+
+| Token | Current | Correct |
+|-------|---------|---------|
+| terminal.ansiWhite | #d0bfa1 | #c5b088 |
+| terminal.ansiBrightBlack | #918175 | #917e6b |
+| terminal.ansiBrightCyan | #53fde9 | #2be4d0 |
+
+### 2. UI colors using off-palette bright_black (propagate correction)
+
+All occurrences of `#918175` (wrong bright_black) → `#917e6b`. Affected tokens:
+`activityBar.inactiveForeground`, `descriptionForeground`, `sideBar.foreground`,
+`list.focusForeground`, `list.hoverForeground`, `panelTitle.inactiveForeground`,
+`peekViewResult.lineForeground`, `titleBar.inactiveForeground`, `textPreformat.foreground`,
+`input.placeholderForeground`.
+
+### 3. Syntax token colors (strict mapping to srcery-vim groups)
+
+| VS Code name | Scope | Current | srcery-vim group | Correct |
+|---|---|---|---|---|
+| Comment | comment | #75715e | Comment → bright_black | #917e6b |
+| String | string | #fbb829 | String → bright_green | #98bc37 |
+| Number | constant.numeric | #0aaeb3 | Number → bright_magenta | #ff5c8f |
+| Built-in constant | constant.language | #0aaeb3 | Constant → bright_magenta | #ff5c8f |
+| User-defined constant | constant.character, constant.other | #0aaeb3 | Constant → bright_magenta | #ff5c8f |
+| Variable | variable | #9ebac2 (non-palette) | Variable → bright_white | #fce8c3 |
+| Storage | storage | #ef2f27 | StorageClass → bright_blue | #68a8e4 |
+| Storage type | storage.type | #2c78bf italic | Type → bright_blue italic | #68a8e4 |
+| Class name | entity.name.class | #519f50 underline | Structure → cyan | #0aaeb3 |
+| Function name | entity.name.function | #519f50 | Function → yellow | #fbb829 |
+| Function argument | variable.parameter | #2c78bf italic | Identifier → bright_blue italic | #68a8e4 |
+| Tag name | entity.name.tag | #ef2f27 | Tag → blue | #2c78bf |
+| Tag attribute | entity.other.attribute-name | #519f50 | Special → blue | #2c78bf |
+| Library class/type | support.type, support.class | #2c78bf italic | Type → bright_blue italic | #68a8e4 |
+
+### 4. New token groups (from srcery-vim, not yet in VS Code theme)
+
+| Group | Vim color | Proposed scope(s) | Hex |
+|---|---|---|---|
+| Boolean | bright_magenta | constant.language.boolean | #ff5c8f |
+| Operator | white | keyword.operator | #c5b088 |
+| Decorator | bright_orange | entity.name.function.decorator, punctuation.definition.decorator | #ff8700 |
+| Include | bright_red | keyword.control.import, keyword.other.import | #f75341 |
+| Define/PreProc | cyan | keyword.control.preprocessor, meta.preprocessor | #0aaeb3 |
+
+### 5. Not changed
+
+- `focusBorder: #75715e` and `peekView.border: #75715e` — intentional VS Code UI choices, not palette errors
+- `terminalCursor.foreground: #6a7c2a` — custom cursor color, not in standard palette; leave it
+- `Keyword` stays at `#ef2f27` (correct match to red)
+- `Library function / Library constant` at `#2c78bf` (correct match to blue/Special)
+
+## Approach
+
+Option A + selective B: fix all wrong color values in-place, add 5 missing token groups at the end of `tokenColors`. Single working branch. No scope renames, no workbench color additions beyond what's listed.
+
+## Success criteria
+
+- All terminal ANSI hex values match srcery-vim palette exactly
+- All syntax token colors map to the correct srcery-vim group color
+- No color values outside the canonical palette remain in tokenColors (except intentional UI overrides noted above)
+- Extension packages without errors (`pnpm exec vsce package`)

--- a/themes/Srcery-color-theme.json
+++ b/themes/Srcery-color-theme.json
@@ -5,13 +5,13 @@
         "activityBar.border": "#1c1b19",
         "activityBar.dropBackground": "#1c1b19",
         "activityBar.foreground": "#fce8c3",
-        "activityBar.inactiveForeground": "#918175",
+        "activityBar.inactiveForeground": "#917e6b",
         "activityBarBadge.background": "#1c1b19",
         "activityBarBadge.foreground": "#fce8c3",
         "button.background": "#2c78bf",
         "button.foreground": "#fce8c3",
         "button.hoverBackground": "#68a8e4",
-        "descriptionForeground": "#918175",
+        "descriptionForeground": "#917e6b",
         "dropdown.background": "#1c1b19",
         "dropdown.listBackground": "#1c1b19",
         "dropdown.border": "#fce8c340",
@@ -39,12 +39,12 @@
         "editorGroup.border": "#fce8c3",
         "editorGroup.dropBackground": "#3f688cB0",
         "editorGroup.emptyBackground": "#121212",
-        "editorGroup.focusedEmptyBorder": "#918175",
+        "editorGroup.focusedEmptyBorder": "#917e6b",
         "editorGroupHeader.noTabsBackground": "#121212",
         "editorGroupHeader.tabsBackground": "#121212",
-        "editorGroupHeader.tabsBorder": "#91817520",
+        "editorGroupHeader.tabsBorder": "#917e6b20",
         "editorLineNumber.activeForeground": "#fbb829",
-        "editorLineNumber.foreground": "#918175",
+        "editorLineNumber.foreground": "#917e6b",
         "editorLink.activeForeground": "#2c78bf",
         "editorSuggestWidget.background": "#303030",
         "editorSuggestWidget.border": "#2d2c29",
@@ -57,7 +57,7 @@
         "input.background": "#1c1b19",
         "input.border": "#1c1b1900",
         "input.foreground": "#fce8c3",
-        "input.placeholderForeground": "#918175",
+        "input.placeholderForeground": "#917e6b",
         "inputOption.activeBorder": "#98bc37",
         "inputValidation.errorBackground": "#872b23",
         "inputValidation.errorBorder": "#f75341",
@@ -73,21 +73,21 @@
         "list.dropBackground": "#1c1b19",
         "list.errorForeground": "#ef2f27",
         "list.focusBackground": "#1c1b19",
-        "list.focusForeground": "#918175",
+        "list.focusForeground": "#917e6b",
         "list.highlightForeground": "#68a8e4",
         "list.hoverBackground": "#1c1b19",
-        "list.hoverForeground": "#918175",
+        "list.hoverForeground": "#917e6b",
         "list.inactiveFocusBackground": "#3f688c",
         "list.inactiveSelectionBackground": "#2d2c29",
         "list.inactiveSelectionForeground": "#68a8e4",
         "list.invalidItemForeground": "#ff0000",
         "list.warningForeground": "#fbb829",
         "panel.background": "#121212",
-        "panel.border": "#918175",
+        "panel.border": "#917e6b",
         "panel.dropBackground": "#1c1b1940",
         "panelTitle.activeBorder": "#fce8c3",
         "panelTitle.activeForeground": "#fce8c3",
-        "panelTitle.inactiveForeground": "#918175",
+        "panelTitle.inactiveForeground": "#917e6b",
         "peekView.border": "#75715E",
         "peekViewEditor.background": "#272822",
         "peekViewEditorGutter.background": "#121212",
@@ -100,7 +100,7 @@
         "peekViewResult.selectionBackground": "#414339",
         "peekViewResult.selectionForeground": "#fce8c3",
         "peekViewTitle.background": "#121212",
-        "peekViewTitleDescription.foreground": "#918175",
+        "peekViewTitleDescription.foreground": "#917e6b",
         "peekViewTitleLabel.foreground": "#fce8c3",
         "progressBar.background": "#519f50",
         "scrollbar.shadow": "#00000000",
@@ -109,8 +109,8 @@
         "scrollbarSlider.hoverBackground": "#877c69",
         "selection.background": "#657A1A",
         "sideBar.background": "#121212",
-        "sideBar.border": "#918175",
-        "sideBar.foreground": "#918175",
+        "sideBar.border": "#917e6b",
+        "sideBar.foreground": "#917e6b",
         "sideBarSectionHeader.background": "#1c1b19",
         "sideBarSectionHeader.border": "#1c1b19",
         "sideBarSectionHeader.foreground": "#fce8c3",
@@ -118,28 +118,28 @@
         "statusBar.background": "#2d2c29",
         "statusBar.foreground": "#fce8c3",
         "tab.activeBackground": "#4e453f",
-        "tab.activeBorder": "#918175",
-        "tab.activeBorderTop": "#918175",
+        "tab.activeBorder": "#917e6b",
+        "tab.activeBorderTop": "#917e6b",
         "tab.activeForeground": "#fce8c3",
         "tab.activeModifiedBorder": "#e02c6d",
         "tab.border": "#12121200",
         "tab.hoverBackground": "#4e453fa0",
         "tab.hoverBorder": "#3f688c",
         "tab.inactiveBackground": "#121212",
-        "tab.inactiveForeground": "#918175",
+        "tab.inactiveForeground": "#917e6b",
         "tab.inactiveModifiedBorder": "#e02c6d",
         "tab.unfocusedActiveBorder": "#1c1b19",
         "tab.unfocusedActiveBorderTop": "#4e453f",
         "tab.unfocusedActiveForeground": "#fce8c3",
         "tab.unfocusedActiveModifiedBorder": "#e02c6d",
         "tab.unfocusedHoverBackground": "#4e453fa0",
-        "tab.unfocusedInactiveForeground": "#918175",
+        "tab.unfocusedInactiveForeground": "#917e6b",
         "tab.unfocusedInactiveModifiedBorder": "#e02c6d",
         "terminal.ansiBlack": "#1c1b19",
         "terminal.ansiBlue": "#2c78bf",
-        "terminal.ansiBrightBlack": "#918175",
+        "terminal.ansiBrightBlack": "#917e6b",
         "terminal.ansiBrightBlue": "#68a8e4",
-        "terminal.ansiBrightCyan": "#53fde9",
+        "terminal.ansiBrightCyan": "#2be4d0",
         "terminal.ansiBrightGreen": "#98bc37",
         "terminal.ansiBrightMagenta": "#ff5c8f",
         "terminal.ansiBrightRed": "#f75341",
@@ -149,7 +149,7 @@
         "terminal.ansiGreen": "#519f50",
         "terminal.ansiMagenta": "#e02c6d",
         "terminal.ansiRed": "#ef2f27",
-        "terminal.ansiWhite": "#d0bfa1",
+        "terminal.ansiWhite": "#c5b088",
         "terminal.ansiYellow": "#fbb829",
         "terminal.background": "#1c1b19",
         "terminalCursor.foreground": "#6A7C2A",
@@ -159,10 +159,10 @@
         "textCodeBlock.background": "#1c1b19",
         "textLink.activeForeground": "#68a8e4",
         "textLink.foreground": "#2c78bf",
-        "textPreformat.foreground": "#918175",
+        "textPreformat.foreground": "#917e6b",
         "textSeparator.foreground": "#fbb829",
         "titleBar.activeForeground": "#fce8c3",
-        "titleBar.inactiveForeground": "#918175",
+        "titleBar.inactiveForeground": "#917e6b",
         "widget.shadow": "#121212"
     },
     "tokenColors": [
@@ -176,28 +176,28 @@
             "name": "Comment",
             "scope": "comment",
             "settings": {
-                "foreground": "#75715E"
+                "foreground": "#917e6b"
             }
         },
         {
             "name": "String",
             "scope": "string",
             "settings": {
-                "foreground": "#fbb829"
+                "foreground": "#98bc37"
             }
         },
         {
             "name": "Number",
             "scope": "constant.numeric",
             "settings": {
-                "foreground": "#0aaeb3"
+                "foreground": "#ff5c8f"
             }
         },
         {
             "name": "Built-in constant",
             "scope": "constant.language",
             "settings": {
-                "foreground": "#0aaeb3"
+                "foreground": "#ff5c8f"
             }
         },
         {
@@ -207,14 +207,14 @@
                 "constant.other"
             ],
             "settings": {
-                "foreground": "#0aaeb3"
+                "foreground": "#ff5c8f"
             }
         },
         {
             "name": "Variable",
             "scope": "variable",
             "settings": {
-                "foreground": "#9ebac2"
+                "foreground": "#fce8c3"
             }
         },
         {
@@ -229,7 +229,7 @@
             "scope": "storage",
             "settings": {
                 "fontStyle": "",
-                "foreground": "#ef2f27"
+                "foreground": "#68a8e4"
             }
         },
         {
@@ -237,7 +237,7 @@
             "scope": "storage.type",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#2c78bf"
+                "foreground": "#68a8e4"
             }
         },
         {
@@ -245,7 +245,7 @@
             "scope": "entity.name.class",
             "settings": {
                 "fontStyle": "underline",
-                "foreground": "#519f50"
+                "foreground": "#0aaeb3"
             }
         },
         {
@@ -261,7 +261,7 @@
             "scope": "entity.name.function",
             "settings": {
                 "fontStyle": "",
-                "foreground": "#519f50"
+                "foreground": "#fbb829"
             }
         },
         {
@@ -269,7 +269,7 @@
             "scope": "variable.parameter",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#2c78bf"
+                "foreground": "#68a8e4"
             }
         },
         {
@@ -277,7 +277,7 @@
             "scope": "entity.name.tag",
             "settings": {
                 "fontStyle": "",
-                "foreground": "#ef2f27"
+                "foreground": "#2c78bf"
             }
         },
         {
@@ -285,7 +285,7 @@
             "scope": "entity.other.attribute-name",
             "settings": {
                 "fontStyle": "",
-                "foreground": "#519f50"
+                "foreground": "#2c78bf"
             }
         },
         {
@@ -312,7 +312,7 @@
             ],
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#2c78bf"
+                "foreground": "#68a8e4"
             }
         },
         {
@@ -436,6 +436,50 @@
             ],
             "settings": {
                 "foreground": "#2c78bf"
+            }
+        },
+        {
+            "name": "Boolean",
+            "scope": "constant.language.boolean",
+            "settings": {
+                "foreground": "#ff5c8f"
+            }
+        },
+        {
+            "name": "Operator",
+            "scope": "keyword.operator",
+            "settings": {
+                "foreground": "#c5b088"
+            }
+        },
+        {
+            "name": "Decorator",
+            "scope": [
+                "entity.name.function.decorator",
+                "punctuation.definition.decorator"
+            ],
+            "settings": {
+                "foreground": "#ff8700"
+            }
+        },
+        {
+            "name": "Include",
+            "scope": [
+                "keyword.control.import",
+                "keyword.other.import"
+            ],
+            "settings": {
+                "foreground": "#f75341"
+            }
+        },
+        {
+            "name": "Define / PreProc",
+            "scope": [
+                "keyword.control.preprocessor",
+                "meta.preprocessor"
+            ],
+            "settings": {
+                "foreground": "#0aaeb3"
             }
         }
     ]


### PR DESCRIPTION
## Summary

Brings `themes/Srcery-color-theme.json` into strict alignment with the canonical [srcery-vim](https://github.com/srcery-colors/srcery-vim) palette and highlight group assignments.

### Terminal ANSI colors (3 fixes)
- `terminal.ansiWhite` `#d0bfa1` → `#c5b088` (white)
- `terminal.ansiBrightBlack` `#918175` → `#917e6b` (bright_black) — propagated across all UI tokens
- `terminal.ansiBrightCyan` `#53fde9` → `#2be4d0` (bright_cyan)

### Syntax token colors synced to srcery-vim groups
| Token | Was | Now | srcery-vim group |
|---|---|---|---|
| Comment | `#75715e` | `#917e6b` | Comment → bright_black |
| String | `#fbb829` | `#98bc37` | String → bright_green |
| Number / Constant | `#0aaeb3` | `#ff5c8f` | Number/Constant → bright_magenta |
| Variable | `#9ebac2` _(non-palette)_ | `#fce8c3` | Variable → bright_white |
| Storage | `#ef2f27` | `#68a8e4` | StorageClass → bright_blue |
| Storage type | `#2c78bf` | `#68a8e4` | Type → bright_blue |
| Class name | `#519f50` | `#0aaeb3` | Structure → cyan |
| Function name | `#519f50` | `#fbb829` | Function → yellow |
| Function argument | `#2c78bf` | `#68a8e4` | Identifier → bright_blue |
| Tag name | `#ef2f27` | `#2c78bf` | Tag → blue |
| Tag attribute | `#519f50` | `#2c78bf` | Special → blue |
| Library class/type | `#2c78bf` | `#68a8e4` | Type → bright_blue |

### New token groups (from srcery-vim, previously missing)
- **Boolean** (`constant.language.boolean`) → bright_magenta `#ff5c8f`
- **Operator** (`keyword.operator`) → white `#c5b088`
- **Decorator** (`entity.name.function.decorator`, `punctuation.definition.decorator`) → bright_orange `#ff8700`
- **Include** (`keyword.control.import`, `keyword.other.import`) → bright_red `#f75341`
- **Define / PreProc** (`keyword.control.preprocessor`, `meta.preprocessor`) → cyan `#0aaeb3`

## Test plan
- [ ] Load extension in VS Code Extension Development Host (F5) and verify syntax highlighting looks correct across a few languages (JS/TS, Python, HTML, CSS)
- [ ] Check terminal colors match the srcery palette
- [ ] Verify `pnpm exec vsce package` succeeds ✅